### PR TITLE
bell's unternull adjustments

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -229,6 +229,13 @@ local function on_metadata_inventory_take(pos, listname, index, stack, player)
 	return
 end
 
+local function on_metadata_inventory_move(pos, from_list, from_index, to_list, to_index, count, player)
+	update_timer(pos)
+	update_nodebox(pos)
+	minetest.log('action', player:get_player_name() .. ' mives stuff inside compost bin at ' .. minetest.pos_to_string(pos))
+	return
+end
+
 local function allow_metadata_inventory_move(pos, from_list, from_index, to_list, to_index, count, player)
 	local inv = minetest.get_meta(pos):get_inventory()
 	if from_list == to_list then 
@@ -305,6 +312,7 @@ minetest.register_node("compost:wood_barrel_empty", {
 	allow_metadata_inventory_move = allow_metadata_inventory_move,
 	on_metadata_inventory_put = on_metadata_inventory_put,
 	on_metadata_inventory_take = on_metadata_inventory_take,
+	on_metadata_inventory_move = on_metadata_inventory_move,
 	on_punch = on_punch,
 })
 
@@ -340,6 +348,7 @@ minetest.register_node("compost:wood_barrel", {
 	allow_metadata_inventory_move = allow_metadata_inventory_move,
 	on_metadata_inventory_put = on_metadata_inventory_put,
 	on_metadata_inventory_take = on_metadata_inventory_take,
+	on_metadata_inventory_move = on_metadata_inventory_move,
 	on_punch = on_punch,
 })
 

--- a/mod.conf
+++ b/mod.conf
@@ -1,0 +1,1 @@
+name = compost


### PR DESCRIPTION
That is the compost mod as I like it
  - inventory: input is 4x2 now.
  - The composing starts if each 8x slots contains at least one compatible item
  - Adjusted place on_punch for simple distribution to the slots
  - Output inventory is 2x2 now for gifts place
  - add random rare gifts (seeds, flowers, saplings ...) in output instead of dirt

You can merge the whole PR or just select some changes as you like. Not the "1. Flora" is done on my List ;) The "gifts" are very rare, but it is ok, since you need just 1 of each item because it all (should be) renewable.
If you like the "The composing starts if each 8x slots contains at least one compatible item" change, may you can change the text to "To start ... each slot". It should be intuitive this way with the hint for everyone.
My test result: Using 20x compost's I get in 1 hour (real time) 2x flowers, 1x wheat seed and 2x different saplings, and ~500 dirt 